### PR TITLE
Kill all related process when exiting

### DIFF
--- a/[fix] package-json
+++ b/[fix] package-json
@@ -22,7 +22,8 @@
     "axios": "0.27.2",
     "electron-squirrel-startup": "^1.0.0",
     "esm": "^3.2.25",
-    "execa": "^5.1.1"
+    "execa": "^5.1.1",
+    "pidtree": "^0.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.20",


### PR DESCRIPTION
I noticed that on Windows the processes are not exited correctly.
The `execa` package create an Rscript process that launches the `start-shiny.R` script in main folder. This in turn creates an R process and another Rscript process, both related to the Shiny dashboard.

When closing the main window the main process created by `execa` is terminated but the other two are left there as zombie processes and the Shiny dashboard can still be accessed if a web browser is pointed to the correct port.

I propose a workaround I implemented for an upcoming app we are developing at my university that is based on [this comment](https://github.com/sindresorhus/execa/issues/96#issuecomment-928268856) I found in a related issue on the execa GitHub.

The related pid of the process are kept in memory and manually terminated when exiting if they are still alive.